### PR TITLE
feat(input): strip UTF-8 BOM from input data

### DIFF
--- a/internal/input/loader.go
+++ b/internal/input/loader.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,12 @@ import (
 	"github.com/kiki-ki/go-qo/internal/db"
 	"github.com/kiki-ki/go-qo/internal/parser"
 )
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+func stripBOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
 
 // LoaderOptions configures loader behavior.
 type LoaderOptions struct {
@@ -86,6 +93,7 @@ func (l *Loader) LoadFiles(filePaths []string) error {
 
 // parseBytes parses byte data based on the format.
 func (l *Loader) parseBytes(data []byte) (*parser.ParsedData, error) {
+	data = stripBOM(data)
 	switch l.format {
 	case FormatJSON:
 		return parser.ParseJSONBytes(data)
@@ -102,16 +110,9 @@ func (l *Loader) parseBytes(data []byte) (*parser.ParsedData, error) {
 
 // parseFile parses a file based on the format.
 func (l *Loader) parseFile(path string) (*parser.ParsedData, error) {
-	switch l.format {
-	case FormatJSON:
-		return parser.ParseFile(path)
-	case FormatCSV:
-		return parser.ParseCSVFile(path, parser.CSVOptions{NoHeader: l.options.NoHeader})
-	case FormatTSV:
-		return parser.ParseCSVFile(path, parser.CSVOptions{NoHeader: l.options.NoHeader, Delimiter: '\t'})
-	case FormatPSV:
-		return parser.ParseCSVFile(path, parser.CSVOptions{NoHeader: l.options.NoHeader, Delimiter: '|'})
-	default:
-		return nil, fmt.Errorf("unsupported format: %s", l.format)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
 	}
+	return l.parseBytes(data)
 }

--- a/internal/input/loader_test.go
+++ b/internal/input/loader_test.go
@@ -1,6 +1,7 @@
 package input_test
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -88,6 +89,28 @@ func TestLoader_LoadFiles(t *testing.T) {
 			checkName:     true,
 			expectedName:  "Alice",
 			nameQuery:     "SELECT name FROM single",
+		},
+		{
+			name:          "JSON with BOM",
+			filePath:      testutil.JSONTestdataPath("bom.json"),
+			format:        input.FormatJSON,
+			wantErr:       false,
+			tableName:     "bom",
+			expectedCount: 3,
+			checkName:     true,
+			expectedName:  "Alice",
+			nameQuery:     "SELECT name FROM bom WHERE id = 1",
+		},
+		{
+			name:          "CSV with BOM",
+			filePath:      testutil.CSVTestdataPath("bom.csv"),
+			format:        input.FormatCSV,
+			wantErr:       false,
+			tableName:     "bom",
+			expectedCount: 3,
+			checkName:     true,
+			expectedName:  "Alice",
+			nameQuery:     "SELECT name FROM bom WHERE id = 1",
 		},
 	}
 
@@ -235,5 +258,58 @@ func TestLoader_LoadFiles_MultipleFiles(t *testing.T) {
 	}
 	if nestedCount != 2 {
 		t.Errorf("expected 2 nested records, got %d", nestedCount)
+	}
+}
+
+func TestLoader_LoadReader_BOM(t *testing.T) {
+	bom := []byte{0xEF, 0xBB, 0xBF}
+
+	tests := []struct {
+		name         string
+		data         []byte
+		format       input.Format
+		expectedName string
+	}{
+		{
+			name:         "CSV with BOM",
+			data:         append(bom, []byte("name,age\nAlice,30\n")...),
+			format:       input.FormatCSV,
+			expectedName: "Alice",
+		},
+		{
+			name:         "JSON with BOM",
+			data:         append(bom, []byte(`[{"name":"Alice","age":30}]`)...),
+			format:       input.FormatJSON,
+			expectedName: "Alice",
+		},
+		{
+			name:         "CSV without BOM",
+			data:         []byte("name,age\nAlice,30\n"),
+			format:       input.FormatCSV,
+			expectedName: "Alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, err := db.New()
+			if err != nil {
+				t.Fatalf("failed to create db: %v", err)
+			}
+			testutil.CloseDB(t, database)
+
+			loader := input.NewLoader(database, tt.format, nil)
+			if err := loader.LoadReader(bytes.NewReader(tt.data), "test"); err != nil {
+				t.Fatalf("LoadReader failed: %v", err)
+			}
+
+			var name string
+			if err := database.QueryRow("SELECT name FROM test LIMIT 1").Scan(&name); err != nil {
+				t.Fatalf("query failed: %v", err)
+			}
+			if name != tt.expectedName {
+				t.Errorf("expected %q, got %q", tt.expectedName, name)
+			}
+		})
 	}
 }

--- a/internal/parser/csv.go
+++ b/internal/parser/csv.go
@@ -179,3 +179,9 @@ func (p *CSVParser) convertValue(val string, dataType DataType) any {
 		return val
 	}
 }
+
+// ParseCSVBytes parses CSV data from a byte slice.
+func ParseCSVBytes(data []byte, options CSVOptions) (*ParsedData, error) {
+	p := &CSVParser{Options: options}
+	return p.ParseBytes(data)
+}

--- a/internal/parser/csv.go
+++ b/internal/parser/csv.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -18,29 +17,6 @@ type CSVOptions struct {
 // CSVParser implements Parser interface for CSV files.
 type CSVParser struct {
 	Options CSVOptions
-}
-
-// init registers CSV and PSV parsers.
-func init() {
-	Register(&CSVParser{})
-	Register(&CSVParser{Options: CSVOptions{Delimiter: '|'}})
-}
-
-// SupportedExtensions returns the file extensions this parser handles.
-func (p *CSVParser) SupportedExtensions() []string {
-	if p.Options.Delimiter == '|' {
-		return []string{".psv"}
-	}
-	return []string{".csv"}
-}
-
-// Parse parses a CSV file into ParsedData.
-func (p *CSVParser) Parse(path string) (*ParsedData, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
-	}
-	return p.ParseBytes(data)
 }
 
 // ParseBytes parses CSV from a byte slice.

--- a/internal/parser/csv_test.go
+++ b/internal/parser/csv_test.go
@@ -138,23 +138,6 @@ func TestCSVParser_TypeInference(t *testing.T) {
 	}
 }
 
-func TestCSVParser_ParseFile(t *testing.T) {
-	p := &parser.CSVParser{}
-
-	result, err := p.Parse("../../testdata/csv/simple.csv")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(result.Columns) != 3 {
-		t.Errorf("columns: got %d, want 3", len(result.Columns))
-	}
-
-	if len(result.Rows) != 3 {
-		t.Errorf("rows: got %d, want 3", len(result.Rows))
-	}
-}
-
 func TestCSVParser_NoHeader(t *testing.T) {
 	p := &parser.CSVParser{Options: parser.CSVOptions{NoHeader: true}}
 

--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -4,32 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/tidwall/gjson"
 )
 
 // JSONParser implements Parser interface for JSON files.
 type JSONParser struct{}
-
-// init registers the JSON parser.
-func init() {
-	Register(&JSONParser{})
-}
-
-// SupportedExtensions returns the file extensions this parser handles.
-func (p *JSONParser) SupportedExtensions() []string {
-	return []string{".json", ".jsonl", ".ndjson"}
-}
-
-// Parse parses a JSON file into ParsedData.
-func (p *JSONParser) Parse(path string) (*ParsedData, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read file %s: %w", path, err)
-	}
-	return p.ParseBytes(data)
-}
 
 // ParseBytes parses JSON or JSON Lines from a byte slice.
 func (p *JSONParser) ParseBytes(data []byte) (*ParsedData, error) {

--- a/internal/parser/json_test.go
+++ b/internal/parser/json_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/kiki-ki/go-qo/internal/parser"
-	"github.com/kiki-ki/go-qo/internal/testutil"
 )
 
 func TestJSONParser_ParseBytes(t *testing.T) {
@@ -194,34 +193,6 @@ func TestJSONParser_ParseBytes(t *testing.T) {
 				tt.checkValues(t, data)
 			}
 		})
-	}
-}
-
-func TestParseFile(t *testing.T) {
-	content := `[{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]`
-	path := testutil.CreateTempJSON(t, content)
-
-	data, err := parser.ParseFile(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(data.Rows) != 2 {
-		t.Errorf("expected 2 rows, got %d", len(data.Rows))
-	}
-}
-
-func TestParseFile_FileNotFound(t *testing.T) {
-	_, err := parser.ParseFile("/nonexistent/file.json")
-	if err == nil {
-		t.Error("expected error for nonexistent file")
-	}
-}
-
-func TestGetParser_UnsupportedFormat(t *testing.T) {
-	_, err := parser.GetParser("file.xml")
-	if err == nil {
-		t.Error("expected error for unsupported format")
 	}
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -46,9 +46,3 @@ func (pd *ParsedData) ColumnNames() []string {
 	}
 	return names
 }
-
-// ParseCSVBytes parses CSV data from a byte slice.
-func ParseCSVBytes(data []byte, options CSVOptions) (*ParsedData, error) {
-	p := &CSVParser{Options: options}
-	return p.ParseBytes(data)
-}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,11 +1,5 @@
 package parser
 
-import (
-	"fmt"
-	"path/filepath"
-	"strings"
-)
-
 // DataType represents the SQL column type.
 type DataType int
 
@@ -53,53 +47,8 @@ func (pd *ParsedData) ColumnNames() []string {
 	return names
 }
 
-// Parser defines the interface for file parsers.
-type Parser interface {
-	Parse(path string) (*ParsedData, error)
-	SupportedExtensions() []string
-}
-
-// ByteParser defines the interface for parsers that can parse byte slices.
-type ByteParser interface {
-	Parser
-	ParseBytes(data []byte) (*ParsedData, error)
-}
-
-var registry = make(map[string]Parser)
-
-// Register adds a parser to the registry.
-func Register(p Parser) {
-	for _, ext := range p.SupportedExtensions() {
-		registry[strings.ToLower(ext)] = p
-	}
-}
-
-// GetParser returns the parser for the given file path.
-func GetParser(path string) (Parser, error) {
-	ext := strings.ToLower(filepath.Ext(path))
-	if p, ok := registry[ext]; ok {
-		return p, nil
-	}
-	return nil, fmt.Errorf("unsupported file format: %s", ext)
-}
-
-// ParseFile parses a file using the appropriate parser.
-func ParseFile(path string) (*ParsedData, error) {
-	p, err := GetParser(path)
-	if err != nil {
-		return nil, err
-	}
-	return p.Parse(path)
-}
-
 // ParseCSVBytes parses CSV data from a byte slice.
 func ParseCSVBytes(data []byte, options CSVOptions) (*ParsedData, error) {
 	p := &CSVParser{Options: options}
 	return p.ParseBytes(data)
-}
-
-// ParseCSVFile parses a CSV file.
-func ParseCSVFile(path string, options CSVOptions) (*ParsedData, error) {
-	p := &CSVParser{Options: options}
-	return p.Parse(path)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -45,6 +45,11 @@ func JSONTestdataPath(filename string) string {
 	return TestdataPath(filepath.Join("json", filename))
 }
 
+// CSVTestdataPath returns the absolute path to a CSV file in testdata/csv.
+func CSVTestdataPath(filename string) string {
+	return TestdataPath(filepath.Join("csv", filename))
+}
+
 // CloseDB registers a cleanup function to close the database when the test completes.
 func CloseDB(t *testing.T, c io.Closer) {
 	t.Helper()

--- a/testdata/csv/bom.csv
+++ b/testdata/csv/bom.csv
@@ -1,0 +1,4 @@
+﻿id,name,age
+1,Alice,30
+2,Bob,25
+3,Charlie,35

--- a/testdata/json/bom.json
+++ b/testdata/json/bom.json
@@ -1,0 +1,5 @@
+﻿[
+  {"id": 1, "name": "Alice", "email": "alice@example.com", "age": 30},
+  {"id": 2, "name": "Bob", "email": "bob@example.com", "age": 25},
+  {"id": 3, "name": "Charlie", "email": "charlie@example.com", "age": 35}
+]


### PR DESCRIPTION
## Summary
- Strip UTF-8 BOM (U+FEFF) from input data before parsing
- Fix an issue where BOM bytes were included in the first column name, causing queries like `SELECT id FROM ...` to fail with "no such column"
- Consolidate `parseFile` into `parseBytes` so BOM stripping applies to all input paths (stdin and files)
- Remove unused file-based parsing API (`Parser` interface, registry, `GetParser`, `ParseFile`, `ParseCSVFile`, per-parser `Parse(path)` / `SupportedExtensions` / `init()`) that became dead code after the consolidation

## Test plan
- [x] Add `LoadReader` tests for BOM-prefixed CSV and JSON
- [x] Add `LoadFiles` tests using BOM-prefixed testdata files
- [x] Verify non-BOM data is unaffected
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)